### PR TITLE
Allow use of topic metadata instead of samples in V2.

### DIFF
--- a/rawdata-converter-core/src/main/java/no/ssb/rawdata/converter/core/convert/RawdataConverterV2.java
+++ b/rawdata-converter-core/src/main/java/no/ssb/rawdata/converter/core/convert/RawdataConverterV2.java
@@ -1,0 +1,21 @@
+package no.ssb.rawdata.converter.core.convert;
+
+import no.ssb.rawdata.api.RawdataMessage;
+import no.ssb.rawdata.api.RawdataMetadataClient;
+
+import java.util.Collection;
+
+public interface RawdataConverterV2 extends RawdataConverter {
+
+    /**
+     * Perform initialization and necessary preparations of the converter, such as calculating targetAvroSchema based on
+     * metadata.
+     *
+     * @param metadataClient
+     */
+    void initialize(RawdataMetadataClient metadataClient);
+
+    default void init(Collection<RawdataMessage> sampleRawdataMessages) {
+        // do nothing, we expect call to initialize instead in V2.
+    }
+}

--- a/rawdata-converter-core/src/main/java/no/ssb/rawdata/converter/core/rawdatasource/RawdataConsumers.java
+++ b/rawdata-converter-core/src/main/java/no/ssb/rawdata/converter/core/rawdatasource/RawdataConsumers.java
@@ -3,6 +3,9 @@ package no.ssb.rawdata.converter.core.rawdatasource;
 import lombok.Builder;
 import lombok.Value;
 import no.ssb.rawdata.api.RawdataConsumer;
+import no.ssb.rawdata.api.RawdataMetadataClient;
+
+import java.util.function.Supplier;
 
 @Value
 @Builder
@@ -11,12 +14,17 @@ public class RawdataConsumers {
      * Rawdata consumer with starting position at initialPosition. This is the consumer from which rawdata messages
      * are streamed converted.
      */
-    private final RawdataConsumer mainRawdataConsumer;
+    private final Supplier<RawdataConsumer> mainRawdataConsumer;
 
     /**
      * Rawdata consumer with starting position at start of topic. This consumer can be used to inspect/sample
      * rawdata messages in advance of conversion, in order to determine stuff such as target avro schema, etc.
      */
-    private final RawdataConsumer sampleRawdataConsumer;
+    private final Supplier<RawdataConsumer> sampleRawdataConsumer;
+
+    /**
+     * Rawdata metadata-client for topic.
+     */
+    private final Supplier<RawdataMetadataClient> metadataClient;
 
 }


### PR DESCRIPTION
Nytt interface `RawdataConverterV2` kan nå implementeres av converter app istedet for `RawdataConverter`. ConverterJob vil da velge å sende inn `RawdataMetadataClient` via `initialize` metoden istedet for en liste av sample meldinger til `init` metoden.

Dette er da fullt bakoverkompatibelt, og skal dermed unngå endringer i eksisterende apps når de oppgraderer til denne kjernen.